### PR TITLE
Fixed failing pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     author='',
     author_email='',
     license='LGPL',
+    package_dir={'': 'src'},
     packages=['controlbox', 'controlbox.conduit', 'controlbox.config', 'controlbox.connector',
                 'controlbox.protocol', 'controlbox.support'],
     zip_safe=False,

--- a/src/controlbox/connector_discovery_facade.py
+++ b/src/controlbox/connector_discovery_facade.py
@@ -71,7 +71,7 @@ class MaintainedConnection:
         If the connection raises a connection error, it is logged, but not raised
         :return: True if the the connector was tried - the connector was not connected and available
         """
-        connector: Connector = self.connector
+        connector = self.connector
         try_open = not connector.connected and connector.available
         if try_open:
             try:


### PR DESCRIPTION
Can't believe it was this simple.
package_dir is documented in the distutils docs:
https://docs.python.org/3/distutils/setupscript.html#listing-whole-packages